### PR TITLE
suggested changes for vrf default

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ module "nxos_vrf" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_nxos"></a> [nxos](#provider\_nxos) | >= 0.3.3 |
+| <a name="provider_nxos"></a> [nxos](#provider\_nxos) | 0.3.3 |
 
 ## Inputs
 

--- a/main.tf
+++ b/main.tf
@@ -118,12 +118,14 @@ locals {
 }
 
 resource "nxos_vrf" "l3Inst" {
+  count       = var.name == "default" ? 0 : 1 # l3Inst is always present for default VRF, can not be deleted
   name        = var.name
   description = var.description
   encap       = var.vni != null ? "vxlan-${var.vni}" : "unknown"
 }
 
 resource "nxos_vrf_routing" "rtctrlDom" {
+  count               = var.name == "default" ? 0 : 1 # no need to create for default VRF
   vrf                 = var.name
   route_distinguisher = local.rd_dme_format
   depends_on = [

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,9 +1,9 @@
 output "dn" {
-  value       = "sys/inst-${var.name}"
+  value       = var.name == "default" ? "sys/inst-${var.name}" : nxos_vrf.l3Inst[0].id
   description = "Distinguished name of the object."
 }
 
 output "name" {
-  value       = var.name
+  value       = var.name == "default" ? var.name : nxos_vrf.l3Inst[0].name
   description = "VRF name."
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,9 +1,9 @@
 output "dn" {
-  value       = nxos_vrf.l3Inst.id
+  value       = "sys/inst-${var.name}"
   description = "Distinguished name of the object."
 }
 
 output "name" {
-  value       = nxos_vrf.l3Inst.name
+  value       = var.name
   description = "VRF name."
 }


### PR DESCRIPTION
L3Inst for VRF `default` can not be deleted:
```
│ Error: Client Error
│ 
│ Failed to update object, got error: JSON error: {"imdata":[{"error": {"attributes": {"code": "1","text": "Delete of VRF default is
│ not allowed"}}}]}
```

added condition for VRF `default` to not create this resource.